### PR TITLE
Add GitHub Actions workflow for testing and releasing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,36 @@
+name: Release Charts
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      # See https://github.com/helm/chart-releaser-action/issues/6
+      - name: Install Helm
+        run: |
+          curl -sSLo get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get
+          chmod 700 get_helm.sh
+          ./get_helm.sh
+          helm init --client-only
+
+      - name: Add dependency chart repos
+        run: |
+          helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+          helm repo add elastic https://helm.elastic.co
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.0.0-alpha.2
+        env:
+          CR_TOKEN: "${{ secrets.CR_TOKEN }}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,6 +30,21 @@ jobs:
           helm repo add stable https://kubernetes-charts.storage.googleapis.com/
           helm repo add elastic https://helm.elastic.co
 
+      - name: Create kind cluster
+        uses: helm/kind-action@master
+        with:
+          installLocalPathProvisioner: true
+
+      - name: Run chart-testing (lint)
+        uses: helm/chart-testing-action@master
+        with:
+          command: lint
+
+      - name: Run chart-testing (install)
+        uses: helm/chart-testing-action@master
+        with:
+          command: install
+
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.0.0-alpha.2
         env:


### PR DESCRIPTION
You need to do these before merging this PR:
* Create `gh-pages` branch
   * e.g. `git checkout --orphan -b gh-pages; git reset; git commit --allow-empty -m "XXX"; git push origin gh-pages`
* Add personal access token
   * See https://github.com/helm/chart-releaser-action#pre-requisites for details.


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#2: Auto-publish charts in "gh-pages" branch](https://issuehunt.io/repos/230274722/issues/2)
---

IssueHunt has been backed by the following sponsors. [Become a sponsor](https://issuehunt.io/membership/members)
</details>
<!-- /Issuehunt content-->