### PR TITLE
Fix/enable helm test for either helm 2 or 3

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,12 +1,14 @@
 name: Release Valid Charts
 
-on:
-  push:
-    branches:
-      - master
+# on:
+#   push:
+#     branches:
+#       - master
+on: [push]
 env:
   SRC_CHARTS_PATH_BASE: charts
-  ENABLE_INSTALL_TEST: false
+  # ENABLE_INSTALL_TEST: false
+  ENABLE_INSTALL_TEST: true
 
 jobs:
   lint_and_install:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,14 +1,12 @@
 name: Release Valid Charts
 
-# on:
-#   push:
-#     branches:
-#       - master
-on: [push]
+on:
+  push:
+    branches:
+      - master
 env:
   SRC_CHARTS_PATH_BASE: charts
-  # ENABLE_INSTALL_TEST: false
-  ENABLE_INSTALL_TEST: true
+  ENABLE_INSTALL_TEST: false
 
 jobs:
   lint_and_install:

--- a/charts/growi/templates/tests/test-connection.yaml
+++ b/charts/growi/templates/tests/test-connection.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "growi.labels" . | nindent 4 }}
   annotations:
-    "helm.sh/hook": test
+    "helm.sh/hook": test-success
 spec:
   containers:
     - name: wget


### PR DESCRIPTION
Closes #10 

I have confirmed that `growi-test-connection` is executed in helm 2.
https://github.com/ryu-sato/helm-charts/runs/560444469?check_suite_focus=true#step:5:104
