### PR TITLE
Exclude mutable labels from selectors

### DIFF
--- a/charts/growi/templates/_helpers.tpl
+++ b/charts/growi/templates/_helpers.tpl
@@ -43,3 +43,11 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
+
+{{/*
+Labels to use on {deploy|sts}.spec.selector.matchLabels and svc.spec.selector
+*/}}
+{{- define "growi.matchLabels" -}}
+app.kubernetes.io/name: {{ include "growi.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}

--- a/charts/growi/templates/deployment.yaml
+++ b/charts/growi/templates/deployment.yaml
@@ -8,7 +8,7 @@ spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      {{- include "growi.labels" . | nindent 6 }}
+      {{- include "growi.matchLabels" . | nindent 6 }}
   {{- with .Values.strategy }}
   strategy:
     {{- . | toYaml | nindent 4 }}

--- a/charts/growi/templates/service.yaml
+++ b/charts/growi/templates/service.yaml
@@ -12,4 +12,4 @@ spec:
       protocol: TCP
       name: http
   selector:
-    {{- include "growi.labels" . | nindent 4 }}
+    {{- include "growi.matchLabels" . | nindent 4 }}


### PR DESCRIPTION
Some selector fields are marked as immutable by Kubernetes.
Including mutable labels in selectors may prevent updating deployment in specific cases.