### PR TITLE
Imprv/upgrade helm v3 in release workflow

### DIFF
--- a/.github/scripts/install-helm.sh
+++ b/.github/scripts/install-helm.sh
@@ -5,11 +5,11 @@
 # 
 # <Environments>
 # 
-#   HELM_VERSION ... Helm version which will be installed. (default: "2.16.3")
+#   HELM_VERSION ... Helm version which will be installed. (default: "3.5.4")
 # ================================================================================
 set -o pipefail
 
-HELM_VERSION="${HELM_VERSION:-2.16.3}"
+HELM_VERSION="${HELM_VERSION:-3.5.4}"
 
 INSTALL_DIR="/usr/local/bin"
 if [ -f "${INSTALL_DIR}/helm" ]; then

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,7 +27,6 @@ jobs:
 
       - name: Lint charts
         run: |
-          helm init --client-only
           helm lint "${SRC_CHARTS_PATH_BASE}"/*
 
       - name: Install charts and run each chart's test

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,6 +15,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+
+      - name: Install dependent packages
+        run: |
+          apt-get update
+          apt-get install -y curl sudo
       
       - name: Install helm
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,9 +1,9 @@
 name: Release Valid Charts
 
 on:
-  push:
-    branches:
-      - master
+  - push
+  - pull_request
+
 env:
   SRC_CHARTS_PATH_BASE: charts
   ENABLE_INSTALL_TEST: false
@@ -18,8 +18,8 @@ jobs:
 
       - name: Install dependent packages
         run: |
-          apt-get update
-          apt-get install -y curl sudo
+          sudo apt-get update
+          sudo apt-get install -y curl
       
       - name: Install helm
         run: |
@@ -34,9 +34,11 @@ jobs:
         run: |
           ${GITHUB_WORKSPACE}/misc/exec-helm-test.sh --config "${GITHUB_WORKSPACE}/misc/kind-config.yaml" --chartdir "${SRC_CHARTS_PATH_BASE}"
 
+  # This deploying job will be run only when master branch is updated
   release:
     runs-on: ubuntu-18.04
     needs: lint_and_install
+    if: github.ref == 'refs/heads/master'
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Close: #8 

This PR runs `misc/exec-helm-test.sh` with Helm3 in GitHub Actions.
<img width="1430" alt="スクリーンショット 2021-05-21 20 45 57" src="https://user-images.githubusercontent.com/469934/119133477-e96bde80-ba76-11eb-8dd5-08292d3b32b8.png">

This has following changes.

- Change of GitHub Action's configuration file to run lint_and_install job when PR is created and run release job only when master branch is updated.
- Change version of Helm to run in the GitHub Action's runtime environment from v2.16.3 to v3.5.4 which is the latest version at present.