### PR TITLE
Change mountPath to the source folder

### DIFF
--- a/charts/growi/templates/deployment.yaml
+++ b/charts/growi/templates/deployment.yaml
@@ -53,7 +53,7 @@ spec:
         {{- if eq .Values.fileUpload.type "local" }}
           volumeMounts:
           - name: uploads
-            mountPath: "/opt/growi/public/uploads"
+            mountPath: "/data/uploads"
         {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}


### PR DESCRIPTION
If the 'image.tag' parameter is set to a version newer than v4.4.0, the mounted folder cannot be used for data persistence and data will be lost when the pod is recreated.

```
# ? ~ v4.3
/opt/growi/public/uploads -> /data/uploads

# v4.4.0 ~ v6
/opt/growi/packages/app/public/uploads -> /data/uploads
```

**Relevant issue**: https://github.com/weseek/growi/issues/4528

