### PR TITLE
chore: updated values.yaml to use uri instead of url

### DIFF
--- a/charts/growi/values.yaml
+++ b/charts/growi/values.yaml
@@ -71,7 +71,7 @@ affinity: {}
 
 mongodb:
   enabled: true
-  # url: mongodb://my-mongodb.chart-example.local:27017/my-wiki
+  # uri: mongodb://my-mongodb.chart-example.local:27017/my-wiki
   image:
     tag: 3.6.20-debian-9-r33
   auth:
@@ -81,7 +81,7 @@ mongodb:
 
 elasticsearch:
   enabled: true
-  # url: http://my-elasticsearch.chart-example.local:9200/my-wiki
+  # uri: http://my-elasticsearch.chart-example.local:9200/my-wiki
   image: extendwings/growi-elasticsearch
   imageTag: latest
   esMajorVersion: 6


### PR DESCRIPTION
There was an inconsistency between the Helm chart templates and values.yaml regarding the connection settings for MongoDB and Elasticsearch.

https://github.com/weseek/helm-charts/blob/6c3f78c6d559e87903646fa63f5e5ba2760d9e6f/charts/growi/templates/configmap.yaml#L6-L15

In `values.yaml`, the keys were defined as `url`, but the templates referenced `uri`.
This caused the custom values not to be applied when `enabled: false`.

Updated `values.yaml` to use `uri` instead of `url`.
Verified that MongoDB and Elasticsearch connections work correctly with the updated keys.
